### PR TITLE
Model modifications

### DIFF
--- a/models/frustum_pointnets_v1.py
+++ b/models/frustum_pointnets_v1.py
@@ -163,6 +163,9 @@ def get_model(point_cloud, one_hot_vec, is_training, bn_decay=None):
     # select masked points and translate to masked points' centroid
     object_point_cloud_xyz, mask_xyz_mean, end_points = \
         point_cloud_masking(point_cloud, logits, end_points)
+    
+    end_points['object_point_cloud_xyz'] = object_point_cloud_xyz
+    end_points['mask_xyz_mean'] = mask_xyz_mean
 
     # T-Net and coordinate translation
     center_delta, end_points = get_center_regression_net(\

--- a/models/frustum_pointnets_v2.py
+++ b/models/frustum_pointnets_v2.py
@@ -105,7 +105,7 @@ def get_3d_box_estimation_v2_net(object_point_cloud, one_hot_vec,
         is_training=is_training, bn_decay=bn_decay, scope='ssg-layer3')
 
     # Fully connected layers
-    net = tf.reshape(l3_points, [batch_size, -1])
+    net = tf.contrib.layers.flatten(l3_points)
     net = tf.concat([net, one_hot_vec], axis=1)
     net = tf_util.fully_connected(net, 512, bn=True,
         is_training=is_training, scope='fc1', bn_decay=bn_decay)
@@ -147,6 +147,9 @@ def get_model(point_cloud, one_hot_vec, is_training, bn_decay=None):
     # select masked points and translate to masked points' centroid
     object_point_cloud_xyz, mask_xyz_mean, end_points = \
         point_cloud_masking(point_cloud, logits, end_points)
+    
+    end_points['object_point_cloud_xyz'] = object_point_cloud_xyz
+    end_points['mask_xyz_mean'] = mask_xyz_mean
 
     # T-Net and coordinate translation
     center_delta, end_points = get_center_regression_net(\

--- a/models/pointnet_util.py
+++ b/models/pointnet_util.py
@@ -69,9 +69,9 @@ def sample_and_group_all(xyz, points, use_xyz=True):
     '''
     batch_size = xyz.get_shape()[0].value
     nsample = xyz.get_shape()[1].value
-    new_xyz = tf.constant(np.tile(np.array([0,0,0]).reshape((1,1,3)), (batch_size,1,1)),dtype=tf.float32) # (batch_size, 1, 3)
-    idx = tf.constant(np.tile(np.array(range(nsample)).reshape((1,1,nsample)), (batch_size,1,1)))
-    grouped_xyz = tf.reshape(xyz, (batch_size, 1, nsample, 3)) # (batch_size, npoint=1, nsample, 3)
+    new_xyz = tf.zeros(tf.shape(xyz[:,:1,:]),dtype=tf.float32) # (batch_size, 1, 3)
+    idx = tf.tile(np.array(range(nsample)).reshape((1,1,nsample)), tf.shape(xyz[:,:1,:1]))
+    grouped_xyz = tf.reshape(xyz, (-1, 1, nsample, 3)) # (batch_size, npoint=1, nsample, 3)
     if points is not None:
         if use_xyz:
             new_points = tf.concat([xyz, points], axis=2) # (batch_size, 16, 259)


### PR DESCRIPTION
Several changes : 
1.  Modify the models (both v1 and v2) so that they can take arbitrary batch size. 
Currently the batch size is fixed once you create the model, which is not practical when the number of objects varies across different frames. I modified the code so that it can infer the batch size from the tensors' shape automatically, i.e. arbitrary batch size is possible. To use this feature, simply set `batch_size=None`.

2. Delete the duplicated `+size_residuals` at line 109 in file `model_util.py` as suggested in #43. This change requires the model to be retrained..

3. Add `object_point_cloud_xyz` and `mask_xyz_mean` to `end_points` in both v1 and v2, to allow 3d box regression directly from extracted points. That is, suppose we already know that some points belong to an object (for example a car), we can directly regress a 3d box from these points, without passing by the segmentation part.
Example usage (similar as in `test.py`):
```
feed_dict = {ep['object_point_cloud_xyz']: car_points_center_view, # the points belonging to a car, subtracted by its centroid, in center view in frustum
             ep['mask_xyz_mean']: car_centroid, # the centroid in center view in frustum
             ops['one_hot_vec_pl']: one_hot_vec,
             ops['is_training_pl']: False}

batch_centers, batch_heading_scores, batch_heading_residuals, \
batch_size_scores, batch_size_residuals = \
sess.run([ops['center'], ep['heading_scores'], ep['heading_residuals'],
          ep['size_scores'], ep['size_residuals']],
                feed_dict=feed_dict)
```